### PR TITLE
Add python Distutils script to simplify the installation progress

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ readme = f.read()
 f.close()
 
 setup(
-    name='xunlei-downloader',
+    name='xiami-downloader',
     version="0.1.6.14",
     description='Python script for download preview music from xiami.com.',
     long_description=readme,


### PR DESCRIPTION
Just add a simple distutils script, so users can use it to install the scripts other than copy it manually.
